### PR TITLE
feat: configurable separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ color = "#FFFFFF" # this must be a valid color
 focused_color = "#FFFFFF" # to disable a focused_color set this to ""
 icon = "类" # to disable a default icon just set this to ""
 size = "14pt" # must be a valid pango size value
+separator = " " # anything between the icon and window title
 
 # app_id section.  This does an exact string comparison to the app_id or
 # window_properties.class value reported in swaymsg -t get_tree for the window

--- a/src/config.toml
+++ b/src/config.toml
@@ -3,6 +3,7 @@ color = "#FFFFFF"
 focused_color = "#FFFFFF"
 icon = "类"
 size = "14pt"
+separator = " "
 
 [app_id]
 "dev.alextren.Spot" = { icon = "阮", color = "#1ed760" }
@@ -57,7 +58,7 @@ zoom = { icon = "", color = "#2d8cff" }
 "facebook\\.com" = { icon = "", color = "#1877f2" }
 "fastmail\\.com" = { icon = "﫯", color = "#1565c0" }
 "fastmail\\.com/calendar" = { icon = "", color = "#1565c0" }
-"fastmail\\.com/contacts" = { size="11pt", icon = "", color = "#1565c0" }
+"fastmail\\.com/contacts" = { size = "11pt", icon = "", color = "#1565c0" }
 "feedbin\\.com" = { icon = "" }
 "gitbook\\.com" = { icon = "", color = "#346ddb" }
 "github\\.com" = { icon = "" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,9 +138,11 @@ fn set_icon(
     };
     let icon = settings.icon.as_ref().unwrap_or(&global_settings.icon);
     let size = settings.size.as_ref().unwrap_or(&global_settings.size);
+    let separator = &global_settings.separator;
+
     connection.run_command(format!(
-        "[con_id={}] title_format \"<span color='{}' size='{}'>{}</span> %title\"",
-        id, color, size, icon
+        "[con_id={}] title_format \"<span color='{}' size='{}'>{}</span>{}%title\"",
+        id, color, size, icon, separator
     ))?;
     Ok(())
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,11 +8,24 @@ pub struct GlobalSettings {
     pub focused_color: Option<String>,
     pub icon: String,
     pub size: String,
+    pub separator: String,
 }
 
 impl GlobalSettings {
-    pub fn new(color: String, focused_color: Option<String>, icon: String, size: String) -> GlobalSettings {
-        GlobalSettings { color, focused_color, icon, size }
+    pub fn new(
+        color: String,
+        focused_color: Option<String>,
+        icon: String,
+        size: String,
+        separator: String,
+    ) -> GlobalSettings {
+        GlobalSettings {
+            color,
+            focused_color,
+            icon,
+            size,
+            separator,
+        }
     }
 
     pub fn from(mut config: HashMap<String, String>) -> GlobalSettings {
@@ -27,7 +40,16 @@ impl GlobalSettings {
         };
         let icon = config.remove("icon").unwrap();
         let size = config.remove("size").unwrap();
-        GlobalSettings { color, focused_color, icon, size }
+        let separator = config
+            .remove("separator")
+            .unwrap_or(String::from(" "));
+        GlobalSettings {
+            color,
+            focused_color,
+            icon,
+            size,
+            separator,
+        }
     }
 }
 


### PR DESCRIPTION
This is a small change that adds a new entry to the configuration file. It is now possible to configure separator between the icon and title. This can be useful for extending the space or changing the separator to something else entirely. A default value is provided in the default config as well as in code (see [line 45 of settings.rs ](https://github.com/chovanecadam/swaycons/blob/3527a6d296a4a1a986f980b8cfa481996964637b/src/settings.rs#L45)). Default value in code is necessary to support configs without the `separator` entry.